### PR TITLE
Rendering a boolean value as true/false, rather than 1/0 in URL param…

### DIFF
--- a/src/TweetSharp/TwitterService.cs
+++ b/src/TweetSharp/TwitterService.cs
@@ -370,7 +370,7 @@ namespace TweetSharp
                 if (segments[i] is bool)
                 {
                     var flag = (bool) segments[i];
-                    segments[i] = flag ? "1" : "0";
+                    segments[i] = flag ? "true" : "false";
                 }
 
                 if(segments[i] is double)


### PR DESCRIPTION
It seems that the current implementation of the Twitter API server doesn't recognize a Boolean value as 1/0 but needs true/false.  I found this in account/verify_credentials where setting the include_email parameter to 1 doesn't work, but setting it to true does ...