### PR TITLE
trying to add support to REST api for tweet_mode parameter

### DIFF
--- a/src/TweetSharp.Tests/TwitterServiceTests.cs
+++ b/src/TweetSharp.Tests/TwitterServiceTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 using NUnit.Framework;
 
@@ -772,18 +773,119 @@ namespace TweetSharp.Tests.Service
 			}
 		}
 
-		[Test]
-		public void Can_get_tweet()
+        [Test]
+        public void Can_get_tweet_default_tweet_mode()
+        {
+            var service = GetAuthenticatedService();
+            var options = new GetTweetOptions {Id = 778329152193781762};
+            TestSyncAndAsync(options, service.GetTweet, service.GetTweetAsync, tweet =>
+            {
+                Assert.IsNotNull(tweet);
+                Assert.IsNotNull(service.Response);
+                Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
+                Assert.AreEqual(@"Upcoming changes to Tweets - Allows tweets more than 140 characters. Looking at extending TweetMoaSharp @yortw… https://t.co/M4WBDumXl9", tweet.Text);
+            });
+        }
+
+        [Test]
+        public void Can_get_tweet_compat_tweet_mode()
+        {
+            var service = GetAuthenticatedService();
+            var options = new GetTweetOptions {Id = 778329152193781762, TweetMode = "compat"};
+
+            TestSyncAndAsync(options, service.GetTweet, service.GetTweetAsync, tweet =>
+            {
+                Assert.IsNotNull(tweet);
+                Assert.IsNotNull(service.Response);
+                Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
+                Assert.AreEqual(@"Upcoming changes to Tweets - Allows tweets more than 140 characters. Looking at extending TweetMoaSharp @yortw… https://t.co/M4WBDumXl9", tweet.Text);
+            });
+        }
+
+        [Test]
+		public void Can_get_tweet_extended_tweet_mode()
 		{
 			var service = GetAuthenticatedService();
-			var tweet = service.GetTweet(new GetTweetOptions { Id = 10080880705929216 });
+            var options = new GetTweetOptions {Id = 778329152193781762, TweetMode = "extended"};
 
-			Assert.IsNotNull(tweet);
-			Assert.IsNotNull(service.Response);
-			Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
-		}
+            TestSyncAndAsync(options, service.GetTweet, service.GetTweetAsync, tweet =>
+            { 
+                Assert.IsNotNull(tweet);
+			    Assert.IsNotNull(service.Response);
+			    Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
+                Assert.IsNull(tweet.Text);
+                Assert.AreEqual(@"Upcoming changes to Tweets - Allows tweets more than 140 characters. Looking at extending TweetMoaSharp @yortw https://t.co/rJAbUfEK9a https://t.co/UwCfXRETR3", tweet.FullText);
+            });
+        }
 
-		[Test]
+        [Test]
+        public void Can_list_tweets_on_user_timeline_default_tweet_mode()
+        {
+            var service = GetAuthenticatedService();
+            var options = new ListTweetsOnUserTimelineOptions { ScreenName = "collinsauve", SinceId = 778329152193781761, MaxId = 778329152193781763 };
+            TestSyncAndAsync(options, service.ListTweetsOnUserTimeline, service.ListTweetsOnUserTimelineAsync, result =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(service.Response);
+                Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
+
+                var tweets = result.ToArray();
+                Assert.AreEqual(1, tweets.Length);
+
+                var tweet = tweets[0];
+                Assert.AreEqual(@"Upcoming changes to Tweets - Allows tweets more than 140 characters. Looking at extending TweetMoaSharp @yortw… https://t.co/M4WBDumXl9", tweet.Text);
+            });
+        }
+
+        [Test]
+        public void Can_list_tweets_on_user_timeline_compat_tweet_mode()
+        {
+            var service = GetAuthenticatedService();
+            var options = new ListTweetsOnUserTimelineOptions { ScreenName = "collinsauve", SinceId = 778329152193781761, MaxId = 778329152193781763, TweetMode = "compat" };
+            TestSyncAndAsync(options, service.ListTweetsOnUserTimeline, service.ListTweetsOnUserTimelineAsync, result =>
+            { 
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(service.Response);
+                Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
+
+                var tweets = result.ToArray();
+                Assert.AreEqual(1, tweets.Length);
+
+                var tweet = tweets[0];
+                Assert.AreEqual(@"Upcoming changes to Tweets - Allows tweets more than 140 characters. Looking at extending TweetMoaSharp @yortw… https://t.co/M4WBDumXl9", tweet.Text);
+            });
+        }
+
+        [Test]
+        public void Can_list_tweets_on_user_timeline_extended_tweet_mode()
+        {
+            var service = GetAuthenticatedService();
+            var options = new ListTweetsOnUserTimelineOptions { ScreenName = "collinsauve", SinceId = 778329152193781761, MaxId = 778329152193781763, TweetMode = "extended" };
+            TestSyncAndAsync(options, service.ListTweetsOnUserTimeline, service.ListTweetsOnUserTimelineAsync, result =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(service.Response);
+                Assert.AreEqual(HttpStatusCode.OK, service.Response.StatusCode);
+
+                var tweets = result.ToArray();
+                Assert.AreEqual(1, tweets.Length);
+
+                var tweet = tweets[0];
+                Assert.AreEqual(@"Upcoming changes to Tweets - Allows tweets more than 140 characters. Looking at extending TweetMoaSharp @yortw https://t.co/rJAbUfEK9a https://t.co/UwCfXRETR3", tweet.FullText);
+            });
+        }
+
+	    private static void TestSyncAndAsync<TOptions, TResult>(TOptions options, Func<TOptions, TResult> syncFunc, Func<TOptions, Task<TwitterAsyncResult<TResult>>> asyncFunc, Action<TResult> assertFunc)
+	    {
+	        var syncResult = syncFunc(options);
+	        assertFunc(syncResult);
+	        var asyncResultTask = asyncFunc(options);
+	        asyncResultTask.Wait();
+	        assertFunc(asyncResultTask.Result.Value);
+	    }
+
+        [Test]
 		public void Can_get_tweet_with_multiple_images()
 		{
 			var service = GetAuthenticatedService();

--- a/src/TweetSharp/TwitterService.generated.cs
+++ b/src/TweetSharp/TwitterService.generated.cs
@@ -24,24 +24,25 @@ namespace TweetSharp
 		public bool? TrimUser { get; set; }  
 		public bool? ContributorDetails { get; set; }  
 		public bool? IncludeEntities { get; set; } 			
-	}			
- 
-    		
-	public class ListTweetsOnUserTimelineOptions
-	{ 
-		public long? UserId { get; set; }  
-		public string ScreenName { get; set; }  
-		public long? SinceId { get; set; }  
-		public int? Count { get; set; }  
-		public long? MaxId { get; set; }  
-		public bool? TrimUser { get; set; }  
-		public bool? ExcludeReplies { get; set; }  
-		public bool? ContributorDetails { get; set; }  
-		public bool? IncludeRts { get; set; } 			
-	}			
- 
-    		
-	public class ListTweetsOnHomeTimelineOptions
+	}
+
+
+    public class ListTweetsOnUserTimelineOptions
+    {
+        public long? UserId { get; set; }
+        public string ScreenName { get; set; }
+        public long? SinceId { get; set; }
+        public int? Count { get; set; }
+        public long? MaxId { get; set; }
+        public bool? TrimUser { get; set; }
+        public bool? ExcludeReplies { get; set; }
+        public bool? ContributorDetails { get; set; }
+        public bool? IncludeRts { get; set; }
+        public string TweetMode { get; set; }
+    }
+
+
+    public class ListTweetsOnHomeTimelineOptions
 	{ 
 		public int? Count { get; set; }  
 		public long? SinceId { get; set; }  
@@ -60,8 +61,9 @@ namespace TweetSharp
 		public long? MaxId { get; set; }  
 		public bool? TrimUser { get; set; }  
 		public bool? IncludeEntities { get; set; }  
-		public bool? IncludeUserEntities { get; set; } 			
-	}			
+		public bool? IncludeUserEntities { get; set; }
+        public string TweetMode { get; set; }
+    }			
  
     		
 	public class RetweetsOptions
@@ -77,8 +79,9 @@ namespace TweetSharp
 		public long Id { get; set; }  
 		public bool? TrimUser { get; set; }  
 		public bool? IncludeMyRetweet { get; set; }  
-		public bool? IncludeEntities { get; set; } 			
-	}			
+		public bool? IncludeEntities { get; set; }
+        public string TweetMode { get; set; }
+    }			
  
     		
 	public class DeleteTweetOptions
@@ -2653,9 +2656,10 @@ namespace TweetSharp
 			var exclude_replies = options.ExcludeReplies;
 			var contributor_details = options.ContributorDetails;
 			var include_rts = options.IncludeRts;
+		    var tweet_mode = options.TweetMode;
 				
 			
-			return WithHammock<IEnumerable<TwitterStatus>>(_client, "statuses/user_timeline", FormatAsString, "?user_id=", user_id, "&screen_name=", screen_name, "&since_id=", since_id, "&count=", count, "&max_id=", max_id, "&trim_user=", trim_user, "&exclude_replies=", exclude_replies, "&contributor_details=", contributor_details, "&include_rts=", include_rts);
+			return WithHammock<IEnumerable<TwitterStatus>>(_client, "statuses/user_timeline", FormatAsString, "?user_id=", user_id, "&screen_name=", screen_name, "&since_id=", since_id, "&count=", count, "&max_id=", max_id, "&trim_user=", trim_user, "&exclude_replies=", exclude_replies, "&contributor_details=", contributor_details, "&include_rts=", include_rts, "&tweet_mode=", tweet_mode);
 		}
 
         
@@ -2705,9 +2709,9 @@ namespace TweetSharp
 			var trim_user = options.TrimUser;
 			var include_my_retweet = options.IncludeMyRetweet;
 			var include_entities = options.IncludeEntities;
-				
-			
-			return WithHammock<TwitterStatus>(_client, "statuses/show/{id}", FormatAsString, "?id=", id, "&trim_user=", trim_user, "&include_my_retweet=", include_my_retweet, "&include_entities=", include_entities);
+		    var tweet_mode = options.TweetMode;
+
+            return WithHammock<TwitterStatus>(_client, "statuses/show/{id}", FormatAsString, "?id=", id, "&trim_user=", trim_user, "&include_my_retweet=", include_my_retweet, "&include_entities=", include_entities, "&tweet_mode=", tweet_mode);
 		}
 
         
@@ -7875,8 +7879,9 @@ namespace TweetSharp
 			var exclude_replies = options.ExcludeReplies;
 			var contributor_details = options.ContributorDetails;
 			var include_rts = options.IncludeRts;
-			
-			return WithHammockTask<IEnumerable<TwitterStatus>>(_client, "statuses/user_timeline", FormatAsString, "?user_id=", user_id, "&screen_name=", screen_name, "&since_id=", since_id, "&count=", count, "&max_id=", max_id, "&trim_user=", trim_user, "&exclude_replies=", exclude_replies, "&contributor_details=", contributor_details, "&include_rts=", include_rts);
+            var tweet_mode = options.TweetMode;
+
+            return WithHammockTask<IEnumerable<TwitterStatus>>(_client, "statuses/user_timeline", FormatAsString, "?user_id=", user_id, "&screen_name=", screen_name, "&since_id=", since_id, "&count=", count, "&max_id=", max_id, "&trim_user=", trim_user, "&exclude_replies=", exclude_replies, "&contributor_details=", contributor_details, "&include_rts=", include_rts, "&tweet_mode=", tweet_mode);
 		}
         
 		public virtual  Task<TwitterAsyncResult<IEnumerable<TwitterStatus>>> ListTweetsOnHomeTimelineAsync(ListTweetsOnHomeTimelineOptions options)
@@ -7919,8 +7924,9 @@ namespace TweetSharp
 			var trim_user = options.TrimUser;
 			var include_my_retweet = options.IncludeMyRetweet;
 			var include_entities = options.IncludeEntities;
-			
-			return WithHammockTask<TwitterStatus>(_client, "statuses/show/{id}", FormatAsString, "?id=", id, "&trim_user=", trim_user, "&include_my_retweet=", include_my_retweet, "&include_entities=", include_entities);
+            var tweet_mode = options.TweetMode;
+            
+            return WithHammockTask<TwitterStatus>(_client, "statuses/show/{id}", FormatAsString, "?id=", id, "&trim_user=", trim_user, "&include_my_retweet=", include_my_retweet, "&include_entities=", include_entities, "&tweet_mode=", tweet_mode);
 		}
         
 		public virtual  Task<TwitterAsyncResult<TwitterStatus>> DeleteTweetAsync(DeleteTweetOptions options)

--- a/src/TweetSharp/TwitterStatus.cs
+++ b/src/TweetSharp/TwitterStatus.cs
@@ -32,6 +32,7 @@ namespace TweetSharp
 		private bool _isTruncated;
 		private string _source;
 		private string _text;
+        private string _fullText;
 		private TwitterUser _user;
 		private TwitterStatus _retweetedStatus;
 		private TwitterGeoLocation _location;
@@ -46,6 +47,7 @@ namespace TweetSharp
 		private long? _quotedStatusId;
 		private string _quotedStatusIdStr;
 		private TwitterStatus _quotedStatus;
+        private int[] _displayTextRange;
 
 #if !Smartphone && !NET20
 		[DataMember]
@@ -331,7 +333,43 @@ namespace TweetSharp
 			}
 		}
 
-		private string _textAsHtml;
+#if !Smartphone && !NET20
+        [DataMember]
+#endif
+        public virtual string FullText
+        {
+            get { return _fullText; }
+            set
+            {
+                if (_text == value)
+                {
+                    return;
+                }
+
+                _fullText = value;
+                OnPropertyChanged("FullText");
+            }
+        }
+
+#if !Smartphone && !NET20
+        [DataMember]
+#endif
+        public virtual int[] DisplayTextRange
+        {
+            get { return _displayTextRange; }
+            set
+            {
+                if (_displayTextRange == value)
+                {
+                    return;
+                }
+
+                _displayTextRange = value;
+                OnPropertyChanged("DisplayTextRange");
+            }
+        }
+
+        private string _textAsHtml;
 		public virtual string TextAsHtml
 		{
 			get

--- a/src/TweetSharp/_TwitterService.1.Timelines.json
+++ b/src/TweetSharp/_TwitterService.1.Timelines.json
@@ -2,7 +2,7 @@
 IEnumerable<TwitterStatus>, "statuses/mentions_timeline", ListTweetsMentioningMe, int? count, long? since_id, long? max_id, bool? trim_user, bool? contributor_details, bool? include_entities
 
 // https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
-IEnumerable<TwitterStatus>, "statuses/user_timeline", ListTweetsOnUserTimeline, long? user_id, string screen_name, long? since_id, int? count, long? max_id, bool? trim_user, bool? exclude_replies, bool? contributor_details, bool? include_rts
+IEnumerable<TwitterStatus>, "statuses/user_timeline", ListTweetsOnUserTimeline, long? user_id, string screen_name, long? since_id, int? count, long? max_id, bool? trim_user, bool? exclude_replies, bool? contributor_details, bool? include_rts, string tweet_mode
 
 // https://dev.twitter.com/docs/api/1.1/get/statuses/home_timeline
 IEnumerable<TwitterStatus>, "statuses/home_timeline", ListTweetsOnHomeTimeline, int? count, long? since_id, long? max_id, bool? trim_user, bool? exclude_replies, bool? contributor_details, bool? include_entities

--- a/src/TweetSharp/_TwitterService.2.Tweets.json
+++ b/src/TweetSharp/_TwitterService.2.Tweets.json
@@ -2,7 +2,7 @@
 IEnumerable<TwitterStatus>, "statuses/retweets/{id}", Retweets, long id, int? count, bool? trim_user
 
 // https://dev.twitter.com/docs/api/1.1/get/statuses/show/%3Aid
-TwitterStatus, "statuses/show/{id}", GetTweet, long id, bool? trim_user, bool? include_my_retweet, bool? include_entities
+TwitterStatus, "statuses/show/{id}", GetTweet, long id, bool? trim_user, bool? include_my_retweet, bool? include_entities, string tweet_mode
 
 // https://dev.twitter.com/docs/api/1.1/post/statuses/destroy/%3Aid
 TwitterStatus, "statuses/destroy/{id}":POST, DeleteTweet, long id, bool trim_user


### PR DESCRIPTION
See https://dev.twitter.com/overview/api/upcoming-changes-to-tweets

I'm trying to add support for the tweet endpoints that support `tweet_mode=extended`.  This makes the response include a `full_text` instead of `text` property, and a `display_text_range` property.

A couple of problems with this PR:
1. I don't fully understand how Hammock code generation works, so I've probably done something wrong.
2. I've only implemented this on `GetTweet`, `GetTweetAsync`, `ListTweetsOnUserTimeline`, and `ListTweetsOnUserTimelineAsync`.  Any endpoint that can return at least one `TwitterStatus` could potentially have this applied.
