### PR TITLE
remove references to nunit from non-test code

### DIFF
--- a/src/TweetSharp.Net35/TweetSharp.Net35.csproj
+++ b/src/TweetSharp.Net35/TweetSharp.Net35.csproj
@@ -47,10 +47,6 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/TweetSharp.Net35/packages.config
+++ b/src/TweetSharp.Net35/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net35-client" />
-  <package id="NUnit" version="2.6.4" targetFramework="net35-client" />
 </packages>

--- a/src/TweetSharp.Net45/TweetSharp.Net45.csproj
+++ b/src/TweetSharp.Net45/TweetSharp.Net45.csproj
@@ -45,10 +45,6 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/TweetSharp.Net45/packages.config
+++ b/src/TweetSharp.Net45/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/TweetSharp.NetCore/TweetSharp.NetCore.csproj
+++ b/src/TweetSharp.NetCore/TweetSharp.NetCore.csproj
@@ -44,9 +44,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/TweetSharp.NetCore/packages.config
+++ b/src/TweetSharp.NetCore/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
There seems to be no reason to have refs to nunit in some projects. 